### PR TITLE
seperated replace statements in hash to make things more os-agnostic

### DIFF
--- a/pycpanel/__init__.py
+++ b/pycpanel/__init__.py
@@ -12,7 +12,7 @@ def unauthorised():
 class conn(object):
     def __init__(self, hostname, username='root', hash=None, password=None, ssl=True,  verify=False, check_conn=True):
         self.__session__ = requests.Session()
-        if hash != None: hash = hash.replace('\r\n', '')
+        if hash != None: hash = hash.replace('\r', '').replace('\n', '')
         if hash != None: self.__session__.headers.update({'Authorization' : 'WHM %s:%s' % (username,hash)})
         if password != None: self.__session__.auth = (username, password)
         if ssl == True: self.hostname = 'https://' + str(hostname) + ':2087/'


### PR DESCRIPTION
When using 
        if hash != None: hash = hash.replace('\r\n', '')
This does not distinguish between windows and unix environments, to be able to use a hash on a unix environment you can separate the replace statements to catch both carriage returns and newlines with no penalty:
      if hash != None: hash = hash.replace('\r', '').replace('\n', '')
